### PR TITLE
Arrays and Spans

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ That's it! No macros or other setup needed!
 * `std::pair<L, R>`.
 * `std::optional<T>`.
 * `std::array<T, N>`, `std::span<T>` and C-style arrays `T[N]`.
-* `glm::vec2`, `glm::vec3` and `glm::vec4` from the GLM graphics library. 
+* All vector types from the GLM graphics library, e.g. `glm::vec2` and `glm::ivec3`.
     * These are not enabled by default. To enable, add the line `#define INREFL_GLM` above the include.
 
 ### Annotations

--- a/example.cpp
+++ b/example.cpp
@@ -12,20 +12,14 @@
 #include <map>
 #include <print>
 
-enum class weapon
-{
-    none,
-    sword,
-    bow,
-    staff,
-    wand,
-    axe
-};
-
 struct player
 {
+    [[=ImRefl::color]]
+    std::array<float, 3> color;
+
+    int spacetime_coords[4];
+
     glm::vec2 pos;
-    glm::vec3 colour;
 
     [[=ImRefl::color]]
     glm::vec4 rgba;

--- a/imrefl.hpp
+++ b/imrefl.hpp
@@ -37,17 +37,6 @@ template <typename T>
 concept arithmetic = std::integral<T> || std::floating_point<T>;
 
 template <typename E> requires std::is_scoped_enum_v<E>
-constexpr const char* enum_to_string(E value)
-{
-    template for (constexpr auto e : std::define_static_array(std::meta::enumerators_of(^^E))) {
-        if (value == [:e:]) {
-            return std::meta::identifier_of(e).data();
-        }
-    }
-    return "<unnamed>";
-}
-
-template <typename E> requires std::is_scoped_enum_v<E>
 consteval auto enums_of()
 {
     return std::define_static_array(std::meta::enumerators_of(^^E));
@@ -58,6 +47,17 @@ consteval auto nsdm_of()
 {
     const auto ctx = std::meta::access_context::current();
 	return std::define_static_array(std::meta::nonstatic_data_members_of(^^T, ctx));
+}
+
+template <typename E> requires std::is_scoped_enum_v<E>
+constexpr const char* enum_to_string(E value)
+{
+    template for (constexpr auto e : enums_of<E>()) { 
+        if (value == [:e:]) {
+            return std::meta::identifier_of(e).data();
+        }
+    }
+    return "<unnamed>";
 }
 
 template <typename T>


### PR DESCRIPTION
* Implements `std::array<T, N>`, `std::span<T>` and C-style arrays.
* If the dimension is 3 or 4 and the element type is floating point, the color annotations are permitted.
* Reminder to self: if I eventually implement checks to error if an annotation is on a type that cannot use it, I need to remember to leave it relaxed for spans as they can change size. This would require splitting the implementation into runtime and compile-time extents, but maybe that's better anyway.
* Re-implement the `glm::vec2/3/4` types in terms of the span overload. Also generalises to `glm::vec<Size, T, Qual>`, so now we can handle `glm::ivec2/3/4` and other vector types for free.
<img width="774" height="245" alt="image" src="https://github.com/user-attachments/assets/4cf98c88-2c06-4095-ad53-2d2c27c45574" />
