### PR TITLE
Fix Compiler Warnings

### DIFF
--- a/example.cpp
+++ b/example.cpp
@@ -12,12 +12,16 @@
 #include <map>
 #include <print>
 
+struct health_component
+{
+    uint8_t health = 100;
+    bool    invulnerable = false;
+};
+
 struct entity
 {
-    [[=ImRefl::string]]
-    char name[64] = {};
-
-    char bytes[3] = {};
+    std::string name = "Matt";
+    std::optional<health_component> health = health_component{120, true};
 };
 
 int main()


### PR DESCRIPTION
* I was accidentally passing the `config` object to `ImGui::Text` and was getting an "unused parameter" warning. Deleted.
* Simplified the `get_new_config` function, and renamed to `get_config`. It no longer is based off the previous config since I don't think it makes sense. Added `[[maybe_unused]]` to the function param.

Consider the following example:
```cpp
struct health_component
{
    int health = 100;
    bool invulnerable = false;
};

struct entity
{
    std::string name;
    
    [[=ImRefl::drag(0, 300)]]
    health_component health;
};
```
Should the drag annotation be used for the `health` field? That seems odd to me. It maybe should be an error.