### PR TITLE
Radio Buttons for Enums

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A library utilising C++26 reflection features to generate ImGui rendering code at compile time for structs without the need for macro magic or addional boilerplate.
 
+This library is still very much of a proof-of-concept, and the interface will be unstable while I experiment with the ergonomics.
+
 ![Example Image](images/imrefl.png)
 
 Simply include the header, declare your types and call `ImRefl::Input`:
@@ -41,6 +43,7 @@ That's it! No macros or other setup needed!
 | `ImRefl::color`            | Renders the annotated field as a color picker. Works for 3 and 4 dimensional arrays and spans as well as `glm::vec3` and `glm::vec4`. |
 | `ImRefl::color_wheel`      | Similar to the above but a full color wheel. |
 | `ImRefl::string` | For C-style char arrays, formats them as a fixed size string rather than a set of values. |
+| `ImRefl::radio` | For enum classes. Displays the enum as a series of radio buttons rather than a dropdown. |
 
 ## Future work
 * All reasonable standard library types (for some definition of reasonable).

--- a/example.cpp
+++ b/example.cpp
@@ -12,16 +12,19 @@
 #include <map>
 #include <print>
 
-struct health_component
+enum class weapon
 {
-    uint8_t health = 100;
-    bool    invulnerable = false;
+    none, sword, staff, wand, axe, bow
 };
 
 struct entity
 {
-    std::string name = "Matt";
-    std::optional<health_component> health = health_component{120, true};
+    std::string name = "Gandalf";
+
+    [[=ImRefl::radio]]
+    weapon left_hand = weapon::staff;
+
+    weapon right_hand = weapon::sword;
 };
 
 int main()


### PR DESCRIPTION
 * Adds `ImRefl::radio` as an annotation for enum classes. Displays the options as a horizontal list of options rather than a dropdown box.
 * I'm not a massive fan of the current formatting, I'll aim to improve that in another update.
 * The number of annotations are starting to grow a fair amount and it isn't clear which ones can be used with which fields, so I'm going to start giving them a rethink. Will experiment in the next PR.
<img width="827" height="265" alt="image" src="https://github.com/user-attachments/assets/1293bdfc-3077-4d5b-aacc-10bec6a543c7" />

(This is a duplicate PR as I accidentally force-pushed to main)