### PR TITLE
Fix GCC-specific issues

### DIFF
--- a/imrefl.hpp
+++ b/imrefl.hpp
@@ -96,7 +96,7 @@ template <typename T>
 consteval std::optional<T> fetch_annotation(std::meta::info info)
 {
     for (const auto a : std::meta::annotations_of(info)) {
-        if (std::meta::type_of(a) == ^^T) {
+        if (std::meta::remove_cvref(std::meta::type_of(a)) == std::meta::remove_cvref(^^T)) {
             return std::meta::extract<T>(a);
         }
     }


### PR DESCRIPTION
Fixes #18
Fixes #19

This is accomplished by:
- using `#include <meta>` instead of `#include <experimental/meta>`
- using `std::meta::remove_cvref` to normalize types before comparison
  - GCC meta info is more granular than Bloomberg's, so this slips through