### PR TITLE
Add struct separator annotations

### DIFF
--- a/imrefl.hpp
+++ b/imrefl.hpp
@@ -39,7 +39,6 @@ template <std::size_t N>
 constexpr Separator separator(const char (&title)[N]) { return { std::define_static_string(title) }; }
 constexpr Separator separator() { return separator(""); }
 
-
 struct Color {};
 inline static constexpr Color color {};
 


### PR DESCRIPTION
This PR adds two new annotations:
- `ImRefl::separator(bool after = false)`
- `ImRefl::separator_text(const char[N] text, bool after = false)`

The following struct:
```c++
struct Person {
  [[=ImRefl::separator_text("Personal Info")]]

  std::string name;
  int age;
  float height;

  struct Question {
    std::string question;
    std::string answer;
  };

  [[=ImRefl::separator_text("Account Recovery")]]

  [[=ImRefl::readonly]]
  std::string email;

  [[=ImRefl::separator(true)]]
  Question securityQuestions[3];
};
```
is rendered like so:
<img width="378" height="403" alt="image" src="https://github.com/user-attachments/assets/fae941f8-7e5d-49bb-9cb1-7a741cb112f9" />
