### PR TITLE
Always enable tree nodes (and when nested)

### DIFF
--- a/example/example.cpp
+++ b/example/example.cpp
@@ -1,3 +1,4 @@
+#include <climits>
 #include <imgui.h>
 #define IMREFL_GLM
 #include "imrefl.hpp"
@@ -13,8 +14,18 @@
 enum class pet { cat, dog, dragon };
 
 struct entity {
+    [[=ImRefl::readonly]]
+    std::vector<pet> pets = {pet::cat, pet::cat, pet::dragon};
+
+
     std::pair<int, float> p1;
     std::pair<int, float> p2;
+};
+
+struct world
+{
+    [[=ImRefl::readonly]]
+    entity e;
 };
 
 int main()
@@ -47,7 +58,7 @@ int main()
     ImGui_ImplGlfw_InitForOpenGL(window, true);
     ImGui_ImplOpenGL3_Init("#version 330");
 
-    entity player = {};
+    world w = {};
     while (!glfwWindowShouldClose(window)) {
         glfwPollEvents();
 
@@ -56,7 +67,7 @@ int main()
         ImGui::NewFrame();
 
         ImGui::Begin("Debug");
-        ImRefl::Input("Settings", player);
+        ImRefl::Input("Settings",  w);
         ImGui::End();
         ImGui::Render();
 

--- a/imrefl.hpp
+++ b/imrefl.hpp
@@ -229,10 +229,10 @@ constexpr ImGuiTreeNodeFlags get_tree_node_flags(ImReflInputFlags input_flags)
 
 inline bool TreeNodeExNoDisable(const char* label, ImGuiTreeNodeFlags flags)
 {
-    bool want_disabled = ImGui::GetCurrentContext()->DisabledStackSize > 0;
-    if (want_disabled) { ImGui::EndDisabled(); }
+    const int disabled_levels = ImGui::GetCurrentContext()->DisabledStackSize;
+    for (int i = 0; i != disabled_levels; ++i) { ImGui::EndDisabled(); }
     bool open = ImGui::TreeNodeEx(label, flags);
-    if (want_disabled) { ImGui::BeginDisabled(); }
+    for (int i = 0; i != disabled_levels; ++i) { ImGui::BeginDisabled(); }
 
     return open;
 }


### PR DESCRIPTION
The PR to turn off `readonly` mode to allow for tree nodes to be expanded is a good idea, but the current implementation only strips off one layer of `readonly`, so in a nested structure, the inner level is still non expandable. The fix is to remove all layers of `readonly` and reapply them after, which this PR does.

For example, given the following definition:
<img width="637" height="230" alt="image" src="https://github.com/user-attachments/assets/98563fd6-df46-4212-96ae-03731253a03b" />

Before:
<img width="211" height="115" alt="image" src="https://github.com/user-attachments/assets/16200af7-5f3f-4840-bf6a-49b6a18f8970" />

After:
<img width="353" height="171" alt="image" src="https://github.com/user-attachments/assets/cb075442-3364-45c2-bcf2-ab10670565a1" />

with the tree nodes on all levels being expandable.