### PR TITLE
Support for const-qualified types

### DIFF
--- a/imrefl.hpp
+++ b/imrefl.hpp
@@ -248,6 +248,9 @@ inline bool TreeNodeExNoDisable(const char* label, ImGuiTreeNodeFlags flags)
 template <typename T>
 bool Render(const char* name, T& val, const Config& config);
 
+template <typename T>
+bool Render(const char* name, const T& val, const Config& config);
+
 template <typename T> requires std::is_scoped_enum_v<T>
 bool Render(const char* name, T& value, const Config& config);
 
@@ -619,6 +622,18 @@ bool Render(const char* name, T& x, [[maybe_unused]] const Config& config)
     }
 
     return changed;
+}
+
+template <typename T>
+bool Render(const char* name, const T& val, const Config& config)
+{
+    T val_mutable = val;
+
+    ImGui::BeginDisabled();
+    Render(name, val_mutable, config);
+    ImGui::EndDisabled();
+
+    return false;
 }
 
 template <typename T>


### PR DESCRIPTION
Fixes #38 

This PR adds support for const-qualified types and is a prerequisite to #35. Currently rendering a `std::pair` that is retrieved from a `std::(unordered_)map` is not possible since first element will be `const`.