### PR TITLE
Smart pointer support

### DIFF
--- a/example/example.cpp
+++ b/example/example.cpp
@@ -16,16 +16,20 @@
 #include <deque>
 #include <list>
 
-enum class pet { cat, dog, dragon };
-
 struct world
 {
-    std::variant<int, float, std::string> data4 = 5;
-    const std::variant<int, float, std::string> data5 = 5; 
-
-    bool flag = false;
-    const bool flag2 = true;
+    std::unique_ptr<int>   unique;
+    std::shared_ptr<float> shared;
+    std::weak_ptr<float>   weak;
+    std::weak_ptr<int>     expired;
 };
+
+
+auto get_expired()
+{
+    auto x = std::make_shared<int>(5.0f);
+    return std::weak_ptr{x};
+}
 
 int main()
 {
@@ -58,6 +62,10 @@ int main()
     ImGui_ImplOpenGL3_Init("#version 330");
 
     world w = {};
+    w.unique = std::make_unique<int>(5);
+    w.shared = std::make_shared<float>(6.0f);
+    w.weak   = w.shared;
+    w.expired = get_expired();
     while (!glfwWindowShouldClose(window)) {
         glfwPollEvents();
 

--- a/imrefl.hpp
+++ b/imrefl.hpp
@@ -7,6 +7,7 @@
 
 #include <concepts>
 #include <format>
+#include <memory>
 #include <meta>
 #include <optional>
 #include <print>
@@ -454,6 +455,24 @@ bool Render(const char* name, std::variant<Ts...>& value, const Config& config);
 template <typename... Ts>
 bool Render(const char* name, const std::variant<Ts...>& value, const Config& config);
 
+template <typename T, typename Deleter>
+bool Render(const char* name, std::unique_ptr<T, Deleter>& value, const Config& config);
+
+template <typename T, typename Deleter>
+bool Render(const char* name, const std::unique_ptr<T, Deleter>& value, const Config& config);
+
+template <typename T>
+bool Render(const char* name, std::shared_ptr<T>& value, const Config& config);
+
+template <typename T>
+bool Render(const char* name, const std::shared_ptr<T>& value, const Config& config);
+
+template <typename T>
+bool Render(const char* name, std::weak_ptr<T>& value, const Config& config);
+
+template <typename T>
+bool Render(const char* name, const std::weak_ptr<T>& value, const Config& config);
+
 template <aggregate T>
 bool Render(const char* name, T& x, const Config& config);
 
@@ -838,6 +857,70 @@ bool Render(const char* name, const std::variant<Ts...>& value, const Config& co
 
     ImGui::EndDisabled();
     return false;
+}
+
+template <typename T, typename Deleter>
+bool Render(const char* name, std::unique_ptr<T, Deleter>& value, const Config& config)
+{
+    if (value) {
+        return Render(name, *value, config);
+    } else {
+        ImGui::Text("%s: <nullopt>", name);
+        return false;
+    }
+}
+
+template <typename T, typename Deleter>
+bool Render(const char* name, const std::unique_ptr<T, Deleter>& value, const Config& config)
+{
+    if (value) {
+        return Render(name, *value, config);
+    } else {
+        ImGui::Text("%s: <nullopt>", name);
+        return false;
+    }
+}
+
+template <typename T>
+bool Render(const char* name, std::shared_ptr<T>& value, const Config& config)
+{
+    if (value) {
+        return Render(name, *value, config);
+    } else {
+        ImGui::Text("%s: <nullopt>", name);
+        return false;
+    }
+}
+
+template <typename T>
+bool Render(const char* name, const std::shared_ptr<T>& value, const Config& config)
+{
+    if (value) {
+        return Render(name, *value, config);
+    } else {
+        ImGui::Text("%s: <nullopt>", name);
+        return false;
+    }
+}
+
+template <typename T>
+bool Render(const char* name, std::weak_ptr<T>& value, const Config& config)
+{
+    if (value.expired()) {
+        ImGui::Text("%s: <expired>", name);
+        return false;
+    }
+    return Render(name, value.lock(), config);
+}
+
+template <typename T>
+bool Render(const char* name, const std::weak_ptr<T>& value, const Config& config)
+{
+    if (value.expired()) {
+        ImGui::Text("%s: <expired>", name);
+        return false;
+    }
+    return Render(name, value.lock(), config);
 }
 
 template <aggregate T>


### PR DESCRIPTION
* Adds overloads for `std::unique_ptr`, `std::shared_ptr` and `std::weak_ptr`.
* These allow for modifying the inner value if it exists, but does not let you reset/emplace the pointer itself. I think being able to do so (for shared and weak pointers at least) is undesirable since there's no good way to make shared pointers point at existing values.

<img width="800" height="175" alt="image" src="https://github.com/user-attachments/assets/32a29966-858f-4daf-a82f-759eccdfeefa" />