### PR TITLE
Implement drag-and-drop for random access containers

### DIFF
--- a/example/example.cpp
+++ b/example/example.cpp
@@ -20,6 +20,12 @@
 
 struct world
 {
+    std::vector<std::string> names2 = {
+        "Gandalf",
+        "Frodo",
+        "Galadriel",
+        "Aragorn"
+    };
     std::vector<std::string> names = {
         "Gandalf",
         "Frodo",

--- a/imrefl.hpp
+++ b/imrefl.hpp
@@ -291,12 +291,12 @@ bool RenderForwardRange(const char* name, R& range, const Config& config)
                 ImGui::SameLine();
                 ImGui::Selectable(std::format("[{}]", i).c_str());
                 if (ImGui::BeginDragDropSource()) {
-                    ImGui::SetDragDropPayload("ITEM", &i, sizeof(size_t));
+                    ImGui::SetDragDropPayload(name, &i, sizeof(size_t));
                     ImGui::Text("Move");
                     ImGui::EndDragDropSource();
                 }
                 if (ImGui::BeginDragDropTarget()) {
-                    if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("ITEM")) {
+                    if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload(name)) {
                         size_t index = *(const size_t*)payload->Data;
                         if (index != i) {
                             std::swap(range[index], element);


### PR DESCRIPTION
For ranges that satisfy the `std::ranges::random_access_range` concept, it is now possible to drag and drop the elements to move them around:

![drag-and-drop](https://github.com/user-attachments/assets/36cd22d8-b4bc-43dc-ad3f-2013a1dd21a7)

We can add an annotation for disable this, but I want to have a rethink of the currently annotations before doing that.
