### PR TITLE
Experiment: applying annotations externally

### DIFF
--- a/example/example.cpp
+++ b/example/example.cpp
@@ -18,18 +18,24 @@
 #include <set>
 #include <array>
 #include <vector>
+#include <unordered_map>
 #include <string>
 
 struct world
 {
-    std::forward_list<std::string> names = {
-        "Gandalf",
-        "Frodo",
-        "Galadriel",
-        "Aragorn"
-    };
+    float color[3] = {1, 1, 0};
 };
 
+template <>
+struct TypeConfig<world>
+{
+    static consteval std::vector<std::meta::info> annotations(std::meta::info info) {
+        if (info == ^^world::color) {
+            return { ^^ImRefl::color };
+        }
+        return {};
+    }
+};
 
 auto get_expired()
 {

--- a/imrefl.hpp
+++ b/imrefl.hpp
@@ -22,6 +22,14 @@ enum ImReflInputFlags_ {
     ImReflInputFlags_DefaultOpen    = 1 << 0,
 };
 
+template <typename T>
+struct TypeConfig
+{
+    static consteval std::vector<std::meta::info> annotations(std::meta::info info) {
+        return {};
+    }
+};
+
 namespace ImRefl {
 
 struct Ignore {};
@@ -208,8 +216,8 @@ consteval bool check_scalar_style(std::meta::info info)
     return style_count < 2;
 }
 
-template <std::meta::info info>
-constexpr Config get_config()
+template <typename StructType, std::meta::info info>
+consteval Config get_config()
 {
     static_assert(check_scalar_style(info), "too many visual styles given for scalar type");
 
@@ -242,6 +250,12 @@ constexpr Config get_config()
         config.is_string = true;
     }
 
+    const auto extra = TypeConfig<StructType>::annotations(info);
+    for (const auto& anno : extra) {
+        if (anno == ^^ImRefl::color) {
+            config.color = true; 
+        }
+    }
     return config;
 }
 
@@ -955,7 +969,7 @@ bool Render(const char* name, T& x, [[maybe_unused]] const Config& config)
         template for (constexpr auto member : nsdm_of<T>()) {
             if constexpr (!has_annotation<Ignore>(member)) {
                 // Previous config does not propagate down to the current struct (with the exception of input_flags)
-                Config new_config = get_config<member>();
+                Config new_config = get_config<T, member>();
                 new_config.input_flags = config.input_flags;
 
                 if constexpr (constexpr auto separator = fetch_annotation<Separator>(member)) {
@@ -985,7 +999,7 @@ bool Render(const char* name, const T& x, [[maybe_unused]] const Config& config)
         template for (constexpr auto member : nsdm_of<T>()) {
             if constexpr (!has_annotation<Ignore>(member)) {
                 // Previous config does not propagate down to the current struct (with the exception of input_flags)
-                Config new_config = get_config<member>();
+                Config new_config = get_config<T, member>();
                 new_config.input_flags = config.input_flags;
 
                 if constexpr (constexpr auto separator = fetch_annotation<Separator>(member)) {


### PR DESCRIPTION
This is a WIP PR, and may not land. I'm experimenting with ways to implement annotations on fields when you cannot edit the type itself. This is one current idea; giving users a struct that they can implement in a similar way to `std::formatter<T>`. It all runs at compile time since I don't want there to be any overhead, but it does mean that users need to write reflection code (not necessarily a bad thing, just maybe unfamiliar to people currently).

This also introduces a third way kind of config, alongside the `Config` struct and the `ImReflInputFlags`. The `Config` is an implementation detail, but the other two are exposed. It might be nice to try and consolidate these things together.

<img width="862" height="308" alt="image" src="https://github.com/user-attachments/assets/1d3aed13-71de-495c-ab7c-f431f8f63080" />
