### PR TITLE
Add nix compatibility + overhaul CMakeFiles + project installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,17 @@
 cmake_minimum_required(VERSION 3.30)
 project(imrefl LANGUAGES CXX)
+include(GNUInstallDirs)
 
 set(CMAKE_CXX_STANDARD 26)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+option(IMREFL_BUILD_EXAMPLE "Build the example" ON)
+
 add_library(ImRefl INTERFACE)
-target_include_directories(ImRefl INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(ImRefl INTERFACE 
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
 
 target_compile_options(ImRefl INTERFACE -freflection)
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
@@ -19,3 +25,7 @@ endif()
 if (IMREFL_BUILD_EXAMPLE)
   add_subdirectory(example)
 endif()
+
+install(TARGETS ImRefl EXPORT ImReflTargets)
+install(FILES imrefl.hpp DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(EXPORT ImReflTargets FILE ImReflConfig.cmake NAMESPACE ImRefl:: DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/ImRefl)

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,24 @@
+{
+  lib,
+  cmake,
+  imgui,
+  gcc16Stdenv,
+  glfw,
+  glm,
+  build_examples ? false,
+}:
+gcc16Stdenv.mkDerivation {
+  pname = "imrefl";
+  version = "0.0.1";
+  cmakeFlags = [
+    "-DIMREFL_BUILD_EXAMPLE=${if build_examples then "ON" else "OFF"}"
+    "-DIMGUI_SOURCE_DIR=${imgui.src}"
+  ];
+  src = lib.cleanSource ./.;
+  buildInputs = [
+    cmake
+    imgui
+    glfw
+    glm
+  ];
+}

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -2,11 +2,21 @@ find_package(glfw3 REQUIRED)
 find_package(OpenGL REQUIRED)
 
 include(FetchContent)
-FetchContent_Declare(
-  imgui
-  GIT_REPOSITORY https://github.com/ocornut/imgui.git
-)
-message("Fetching ImGui...")
+option(IMGUI_SOURCE_DIR "Path to imgui source" "")
+
+if(IMGUI_SOURCE_DIR)
+  message(STATUS "Using local ImGui source from ${IMGUI_SOURCE_DIR}")
+  FetchContent_Declare(
+    imgui
+    SOURCE_DIR ${IMGUI_SOURCE_DIR}
+  )
+else()
+  message(STATUS "Fetching ImGui from git repository")
+  FetchContent_Declare(
+    imgui
+    GIT_REPOSITORY https://github.com/ocornut/imgui.git
+  )
+endif()
 FetchContent_MakeAvailable(imgui)
 
 set(IMGUI_SRC
@@ -47,3 +57,5 @@ target_link_libraries(imrefl-example PRIVATE
   glfw
   ImRefl
 )
+
+install(TARGETS imrefl-example DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,60 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1772380702,
+        "narHash": "sha256-xL79RplrGAj+NmCUeUx6SfeC9fqIipj9sZoljfHSoEQ=",
+        "owner": "rucadi",
+        "repo": "nixpkgs",
+        "rev": "d2f800f9b31a1070face0497129f9b611f955d6a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rucadi",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,43 @@
+{
+  description = "ImRefl - A C++26 reflection library for ImGui";
+
+  inputs = {
+    nixpkgs.url = "github:rucadi/nixpkgs";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+        };
+
+        library = pkgs.callPackage ./default.nix { };
+        with_examples = pkgs.callPackage ./default.nix { build_examples = true; };
+      in
+      {
+        packages.default = library;
+        packages.with_examples = with_examples;
+        apps.default = {
+          type = "app";
+          program = "${with_examples}/bin/imrefl-example";
+        };
+        devShells.default = pkgs.mkShell.override { stdenv = pkgs.gcc16Stdenv; } {
+          packages = [
+            pkgs.cmake
+            pkgs.gcc16
+            pkgs.glfw
+            pkgs.glm
+            pkgs.imgui
+          ];
+        };
+      }
+    );
+}


### PR DESCRIPTION
Hello! Thanks for this project :)

I wanted to test the project, but since it uses snapshot packages from gcc16, it can be a pain to install the required dependencies for this project.

In this case, I added a nix flake + packaging so it is easier to test and play with it.

Due to nix building inside a sandbox without internet, I modified the CMake file to be able to specify a PATH to the ImGui code, instead of always downloading it from git.

I also overhauled (with a little bit of help of gemini ai) the install target of the cmakefiles, which was missing.

Now, it should correctly install with cmake commands into the specified (or system) folder:
In this case, configured to /tmp

```
[rucadi@nixos:~/Repositories/imrefl]$ cmake --install build
-- Install configuration: ""
-- Installing: /tmp/bin/imrefl-example
-- Installing: /tmp/include/imrefl.hpp
-- Installing: /tmp/lib64/cmake/ImRefl/ImReflConfig.cmake
```

However, as I already mentioned, I used gemini because I'm not a Cmake expert by any means. but "looks good to me".

About the nix part:
- Currently, the defined url points to my nixpkgs repo, this is because gcc16 (snapshot) is not yet in nixpkgs repo, the changes are quite minimal, so I'll try to ask if it can be merged, at which point this url can point to the real nixpkgs. Due to that, is not currently in any binary cache, and gcc16 will be built from scratch.

in order to run the test program is it possible to do:

`nix run github:rucadi/imrefl`

or to just build it and generate a folder with it

`nix build github:rucadi/imrefl#with_examples`

(Default package doesn't have the examples build so it can be referenced by other projects but without having to download/build the example).

You can also create a shell with all the dependencies required to build the project with:

`nix develop github:rucadi/imrefl`

Hope this fits well!