### PR TITLE
`ImRefl::Input`: construct config using `^^value`

### DIFF
--- a/imrefl.hpp
+++ b/imrefl.hpp
@@ -944,7 +944,7 @@ bool Render(const char* name, T& val)
 
 bool Input(const char* name, auto& value)
 {
-    constexpr detail::Config config;
+    constexpr auto config = detail::Config{ .self=^^value };
 
     return detail::Render<config>(name, value);
 }


### PR DESCRIPTION
This small PR fixes #52 by creating the `Config` in `ImRefl::Input` with the reflection info from the value passed to the function.