### PR TITLE
Bugfixes: Compile errors for `span<const T>`

### DIFF
--- a/imrefl.hpp
+++ b/imrefl.hpp
@@ -325,7 +325,8 @@ bool RenderForwardRange(const char* name, R& range)
         for (auto& element : range) {
             ImGuiID id(i);
             const std::string index_name = std::format("[{}]", i);
-            if constexpr (std::ranges::random_access_range<R>) {
+            using element_type = std::remove_reference_t<std::ranges::range_reference_t<R>>;
+            if constexpr (!std::is_const_v<element_type> && std::ranges::random_access_range<R>) {
                 changed = Render<config>("", element) || changed;
                 ImGui::SameLine();
                 ImGui::Selectable(index_name.c_str());


### PR DESCRIPTION
This PR addresses two compile errors relating to `std::span<const T>`:
- A typo in the `scalar<T>`/`InLine` path
- A failure to check for the const-ness of the element type before enabling drag and drop/ swapping