### PR TITLE
Refactor `ImRefl::separator()`

### DIFF
--- a/imrefl.hpp
+++ b/imrefl.hpp
@@ -90,9 +90,7 @@ struct NonResizable {};
 inline static constexpr NonResizable non_resizable {};
 
 struct Separator { const char* title; };
-template <std::size_t N>
-constexpr Separator separator(const char (&title)[N]) { return { std::define_static_string(title) }; }
-constexpr Separator separator() { return separator(""); }
+consteval Separator separator(std::string_view title = "") { return {std::define_static_string(title)}; }
 
 struct Color {};
 inline static constexpr Color color {};


### PR DESCRIPTION
This PR cleans up the implementation for the `ImRefl::separator` helper function. Referring to [this](https://stackoverflow.com/a/79875463/32496499) Stack Overflow post, using `string_view` in `define_static_string` requires a `consteval` context.
