### PR TITLE
All `enum` types

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ That's it! No macros or other setup needed!
 ### Supported types
 #### `imrefl.hpp`
 * Aggregate structs.
-* Enum classes.
+* All enumeration types (both C-style `num` and C++ scoped `enum class`).
 * All arithmetic types.
     * `bool` is rendered as a checkbox.
     * `char` is treated as a character rather than an 8 bit integer. 

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -34,18 +34,18 @@ enum class weapon
     axe
 };
 
-using namespace std::chrono_literals;
+enum colour
+{
+    green,
+    blue,
+    red
+};
 
 struct player
 {
-    [[=ImRefl::slider(0, 20)]]
-    std::chrono::duration<float, std::nano>
-        float_duration = std::chrono::duration<float, std::nano>{12.0f};
-
-    std::chrono::seconds num_secs = std::chrono::seconds{10};
-    std::chrono::years age = std::chrono::years{31};
+    weapon current = weapon::wand;
+    colour col = green;
 };
-
 
 int main()
 {

--- a/imrefl.hpp
+++ b/imrefl.hpp
@@ -163,7 +163,7 @@ template <typename T>
 concept scalar = is_arithmetic_type(^^T) && (^^T != ^^bool);
 
 template <typename T>
-concept scoped_enum = is_scoped_enum_type(^^T);
+concept enumeration = is_enum_type(^^T);  // includes scoped enums
 
 template <typename T>
 concept aggregate = is_aggregate_type(^^T);
@@ -265,7 +265,7 @@ consteval auto enums_of(std::meta::info type)
     return std::define_static_array(enumerators_of(type));
 }
 
-template <scoped_enum T>
+template <enumeration T>
 constexpr const char* enum_to_string(T value)
 {
     template for (constexpr auto e : enums_of(^^T)) {
@@ -659,7 +659,7 @@ struct Renderer<config, T>
     }
 };
 
-template <Config config, detail::scoped_enum T>
+template <Config config, detail::enumeration T>
 struct Renderer<config, T>
 {
     static bool Render(const char* name, T& value)


### PR DESCRIPTION
<img width="630" height="446" alt="image" src="https://github.com/user-attachments/assets/a7e15e11-ae59-4617-938e-f0c8f79f54d4" />

* The code currently only supports `enum class` (scoped enums), but there's no reason to restrict ourselves here. The code can handle C-style `enum` as well, which this PR changes.