### PR TITLE
Collapsible regions for aggregates

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,9 @@ That's it! No macros or other setup needed!
 | `ImRefl::radio` | For enum classes. Displays the enum as a series of radio buttons rather than a dropdown. |
 | `ImRefl::in_line` | By default, array-like values are show with each element on a separate line. However, for types such as `float[3]` representing a position, it may be desirable to show them on a single line, which this annotation is for. |
 | `ImRefl::non_resizeable` | For dynamic arrays, this annotation disables the ability to add and remove elements. |
-| `ImRefl::separator(title)` | Adds an ImGui separator line with optional title above the annotated field. | 
+| `ImRefl::separator(title)` | Adds an ImGui separator line with optional title above the annotated field. |
+| `ImRefl::begin_region(title)` | Adds a collapsable region within an aggregate. |
+| `ImRefl::end_region(levels)` | Closes a collapsable region; defaults to 1 level, 0 is used to close all nested regions in the stack. | 
 
 ### Third-party types
 It is possible to implement the rendering logic for custom types by providing an implementation of `ImRefl::Renderer` for your type. For example:

--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ That's it! No macros or other setup needed!
 | `ImRefl::in_line` | By default, array-like values are show with each element on a separate line. However, for types such as `float[3]` representing a position, it may be desirable to show them on a single line, which this annotation is for. |
 | `ImRefl::non_resizeable` | For dynamic arrays, this annotation disables the ability to add and remove elements. |
 | `ImRefl::separator(title)` | Adds an ImGui separator line with optional title above the annotated field. |
-| `ImRefl::begin_region(title)` | Adds a collapsable region within an aggregate. |
-| `ImRefl::end_region(levels)` | Closes a collapsable region; defaults to 1 level, 0 is used to close all nested regions in the stack. | 
+| `ImRefl::begin_region(title)` | Adds a collapsible region within an aggregate. |
+| `ImRefl::end_region(levels)` | Closes a collapsible region; defaults to 1 level, 0 is used to close all nested regions in the stack. | 
 
 ### Third-party types
 It is possible to implement the rendering logic for custom types by providing an implementation of `ImRefl::Renderer` for your type. For example:

--- a/imrefl.hpp
+++ b/imrefl.hpp
@@ -111,13 +111,8 @@ consteval Separator separator(std::string_view title = "") { return {std::define
 struct BeginRegion { const char* title; };
 consteval BeginRegion begin_region(std::string_view title) { return {std::define_static_string(title)}; }
 
-enum class EndRegionMode
-{
-    single,
-    all
-};
-struct EndRegion { EndRegionMode mode; };
-constexpr EndRegion end_region(EndRegionMode mode = EndRegionMode::single) { return {mode}; }
+struct EndRegion { std::size_t levels; };
+constexpr EndRegion end_region(std::size_t levels = 1) { return {levels}; }
 
 struct Color {};
 inline static constexpr Color color {};
@@ -629,13 +624,15 @@ struct Renderer<config, T>
                 constexpr auto new_config = Config{attns.data(), attns.size()};
 
                 if constexpr (new_config.HasAttn<EndRegion>()) {
+                    std::size_t current_levels = 0;
                     while (!region_states.empty()) {
                         if (region_states.top()) {
                             ImGui::TreePop();
                         }
                         region_states.pop();
+                        ++current_levels;
 
-                        if (new_config.FetchAttn<EndRegion>()->mode == EndRegionMode::single) {
+                        if (current_levels == new_config.FetchAttn<EndRegion>()->levels) {
                             break;
                         }
                     }
@@ -685,13 +682,15 @@ struct Renderer<config, T>
                 constexpr auto new_config = Config{attns.data(), attns.size()};
 
                 if constexpr (new_config.HasAttn<EndRegion>()) {
+                    std::size_t current_levels = 0;
                     while (!region_states.empty()) {
                         if (region_states.top()) {
                             ImGui::TreePop();
                         }
                         region_states.pop();
+                        ++current_levels;
 
-                        if (new_config.FetchAttn<EndRegion>()->mode == EndRegionMode::single) {
+                        if (current_levels == new_config.FetchAttn<EndRegion>()->levels) {
                             break;
                         }
                     }

--- a/imrefl.hpp
+++ b/imrefl.hpp
@@ -111,8 +111,13 @@ consteval Separator separator(std::string_view title = "") { return {std::define
 struct BeginRegion { const char* title; };
 consteval BeginRegion begin_region(std::string_view title) { return {std::define_static_string(title)}; }
 
-struct EndRegion {};
-inline static constexpr EndRegion end_region {};
+enum class EndRegionMode
+{
+    single,
+    all
+};
+struct EndRegion { EndRegionMode mode; };
+constexpr EndRegion end_region(EndRegionMode mode = EndRegionMode::single) { return {mode}; }
 
 struct Color {};
 inline static constexpr Color color {};
@@ -624,30 +629,36 @@ struct Renderer<config, T>
                 constexpr auto new_config = Config{attns.data(), attns.size()};
 
                 if constexpr (new_config.HasAttn<EndRegion>()) {
-                    if (region_states.top()) {
-                        ImGui::TreePop();
+                    while (!region_states.empty()) {
+                        if (region_states.top()) {
+                            ImGui::TreePop();
+                        }
+                        region_states.pop();
+
+                        if (new_config.FetchAttn<EndRegion>()->mode == EndRegionMode::single) {
+                            break;
+                        }
                     }
-                    region_states.pop();
                 }
                 if constexpr (new_config.HasAttn<BeginRegion>()) {
                     if (region_states.empty() || region_states.top()) {
                         region_states.push(TreeNodeExNoDisable(new_config.FetchAttn<BeginRegion>()->title));
+                    } else {
+                        region_states.push(false);
                     }
                 }
 
                 if constexpr (!new_config.HasAttn<Ignore>()) {
-                    if (region_states.size() > 0 && region_states.top() == false) {
-                        continue;
-                    }
+                    if (region_states.empty() || region_states.top()) {
+                        if constexpr (constexpr auto separator = new_config.FetchAttn<Separator>()) {
+                            ImGui::SeparatorText(separator->title);
+                        }
 
-                    if constexpr (constexpr auto separator = new_config.FetchAttn<Separator>()) {
-                        ImGui::SeparatorText(separator->title);
-                    }
-
-                    if constexpr (new_config.HasAttn<Readonly>()) {
-                        Input<new_config>(identifier_of(member).data(), std::as_const(x.[:member:]));
-                    } else {
-                        changed = Input<new_config>(identifier_of(member).data(), x.[:member:]) || changed;
+                        if constexpr (new_config.HasAttn<Readonly>()) {
+                            Input<new_config>(identifier_of(member).data(), std::as_const(x.[:member:]));
+                        } else {
+                            changed = Input<new_config>(identifier_of(member).data(), x.[:member:]) || changed;
+                        }
                     }
                 }
             }
@@ -674,14 +685,22 @@ struct Renderer<config, T>
                 constexpr auto new_config = Config{attns.data(), attns.size()};
 
                 if constexpr (new_config.HasAttn<EndRegion>()) {
-                    if (region_states.top()) {
-                        ImGui::TreePop();
+                    while (!region_states.empty()) {
+                        if (region_states.top()) {
+                            ImGui::TreePop();
+                        }
+                        region_states.pop();
+
+                        if (new_config.FetchAttn<EndRegion>()->mode == EndRegionMode::single) {
+                            break;
+                        }
                     }
-                    region_states.pop();
                 }
                 if constexpr (new_config.HasAttn<BeginRegion>()) {
                     if (region_states.empty() || region_states.top()) {
                         region_states.push(TreeNodeExNoDisable(new_config.FetchAttn<BeginRegion>()->title));
+                    } else {
+                        region_states.push(false);
                     }
                 }
 

--- a/imrefl.hpp
+++ b/imrefl.hpp
@@ -18,6 +18,7 @@
 #include <ranges>
 #include <source_location>
 #include <string>
+#include <stack>
 #include <string_view>
 #include <type_traits>
 #include <utility>
@@ -106,6 +107,12 @@ inline static constexpr NonResizable non_resizable {};
 
 struct Separator { const char* title; };
 consteval Separator separator(std::string_view title = "") { return {std::define_static_string(title)}; }
+
+struct BeginRegion { const char* title; };
+consteval BeginRegion begin_region(std::string_view title) { return {std::define_static_string(title)}; }
+
+struct EndRegion {};
+inline static constexpr EndRegion end_region {};
 
 struct Color {};
 inline static constexpr Color color {};
@@ -611,11 +618,27 @@ struct Renderer<config, T>
     {
         bool changed = false;
         if (TreeNodeExNoDisable(name)) {
+            std::stack<bool> region_states;
             template for (constexpr auto member : detail::nsdm_of(^^T)) {
                 constexpr auto attns = detail::get_all_attns(^^T, member);
                 constexpr auto new_config = Config{attns.data(), attns.size()};
 
+                if constexpr (new_config.HasAttn<EndRegion>()) {
+                    if (region_states.top()) {
+                        ImGui::TreePop();
+                    }
+                    region_states.pop();
+                }
+                if constexpr (new_config.HasAttn<BeginRegion>()) {
+                    if (region_states.empty() || region_states.top()) {
+                        region_states.push(TreeNodeExNoDisable(new_config.FetchAttn<BeginRegion>()->title));
+                    }
+                }
+
                 if constexpr (!new_config.HasAttn<Ignore>()) {
+                    if (region_states.size() > 0 && region_states.top() == false) {
+                        continue;
+                    }
 
                     if constexpr (constexpr auto separator = new_config.FetchAttn<Separator>()) {
                         ImGui::SeparatorText(separator->title);
@@ -629,6 +652,13 @@ struct Renderer<config, T>
                 }
             }
 
+            while (!region_states.empty()) {
+                if (region_states.top()) {
+                    ImGui::TreePop();
+                }
+                region_states.pop();
+            }
+
             ImGui::TreePop();
         }
 
@@ -638,11 +668,27 @@ struct Renderer<config, T>
     static bool Render(const char* name, const T& x)
     {
         if (TreeNodeExNoDisable(name)) {
+            std::stack<bool> region_states;
             template for (constexpr auto member : detail::nsdm_of(^^T)) {
                 constexpr auto attns = detail::get_all_attns(^^T, member);
                 constexpr auto new_config = Config{attns.data(), attns.size()};
 
+                if constexpr (new_config.HasAttn<EndRegion>()) {
+                    if (region_states.top()) {
+                        ImGui::TreePop();
+                    }
+                    region_states.pop();
+                }
+                if constexpr (new_config.HasAttn<BeginRegion>()) {
+                    if (region_states.empty() || region_states.top()) {
+                        region_states.push(TreeNodeExNoDisable(new_config.FetchAttn<BeginRegion>()->title));
+                    }
+                }
+
                 if constexpr (!new_config.HasAttn<Ignore>()) {
+                    if (region_states.size() > 0 && region_states.top() == false) {
+                        continue;
+                    }
 
                     if constexpr (constexpr auto separator = new_config.FetchAttn<Separator>()) {
                         ImGui::SeparatorText(separator->title);
@@ -650,6 +696,13 @@ struct Renderer<config, T>
 
                     Input<new_config>(identifier_of(member).data(), x.[:member:]);
                 }
+            }
+
+            while (!region_states.empty()) {
+                if (region_states.top()) {
+                    ImGui::TreePop();
+                }
+                region_states.pop();
             }
 
             ImGui::TreePop();

--- a/imrefl.hpp
+++ b/imrefl.hpp
@@ -704,15 +704,13 @@ struct Renderer<config, T>
                 }
 
                 if constexpr (!new_config.HasAttn<Ignore>()) {
-                    if (region_states.size() > 0 && region_states.top() == false) {
-                        continue;
+                    if (region_states.empty() || region_states.top()) {
+                        if constexpr (constexpr auto separator = new_config.FetchAttn<Separator>()) {
+                            ImGui::SeparatorText(separator->title);
+                        }
+    
+                        Input<new_config>(identifier_of(member).data(), x.[:member:]);
                     }
-
-                    if constexpr (constexpr auto separator = new_config.FetchAttn<Separator>()) {
-                        ImGui::SeparatorText(separator->title);
-                    }
-
-                    Input<new_config>(identifier_of(member).data(), x.[:member:]);
                 }
             }
 


### PR DESCRIPTION
This PR introduces 2 new annotations and functionality for collapsible regions inside of aggregates.

- `begin_region(string_view title)`: starts a new region (tree node) with label `title`
- `end_region`: ends the region on the top of the stack (popping the tree node)
- `end_region` is optional and regions automatically close, but is required when 2 or more distinct (not nested) regions are desired
- nested regions are supported

This code generates the following UI:
```c++
struct Example 
{
    [[=ImRefl::begin_region("Arithmetic types")]]
    bool bool_;
    char char_;

    [[=ImRefl::begin_region("Signed integers")]]
    short short_;
    int int_;
    long int long_int_;
    [[=ImRefl::end_region()]]

    [[=ImRefl::begin_region("Unsigned integers")]]
    unsigned char unsigned_char_;
    unsigned short unsigned_short_;
    unsigned int unsigned_int_;
    unsigned long int unsigned_long_int_;
    [[=ImRefl::end_region()]]

    [[=ImRefl::begin_region("Floating point")]]
    float float_;
    double double_;
    long double long_double_;
    [[=ImRefl::end_region(0)]]

    [[=ImRefl::begin_region("Enum types")]]
    Color enum_color;
    Shape enum_class_shape;
};
```
<img width="569" height="453" alt="imrefl-regions" src="https://github.com/user-attachments/assets/1726b17a-4ec0-4b85-ba7b-27b91f6463f4" />

