### PR TITLE
Bugfix: program hangs when rendering arrays

### DIFF
--- a/imrefl.hpp
+++ b/imrefl.hpp
@@ -466,7 +466,7 @@ bool render_forward_range(const char* name, R& range)
     }
 
     std::size_t i = 0;
-    for (auto it = range.begin(); it != range.end();) {
+    for (auto it = range.begin(); it != range.end(); ++it) {
         changed |= render_range_element<config>(name, i, range, it);
         ++i;
     }


### PR DESCRIPTION
Fixes #98. This issue was caused by forgetting to increment the iterator when looping over the elements of a forward range.