### PR TITLE
Bugfix: `render_range_element`: increment iterator for non-erasable ranges

### DIFF
--- a/imrefl.hpp
+++ b/imrefl.hpp
@@ -410,6 +410,9 @@ bool render_range_element(const char* name, std::size_t i, R& range, std::ranges
             ++it;
         }
     }
+    else {
+        ++it;
+    }
 
     return changed;
 }


### PR DESCRIPTION
Fixes #98. The range iterator is only incremented when its elements are erasable, causing an infinite loop while rendering containers that do not satisfy this constraint. This PR addresses this issue.