### PR TITLE
`std::indirect<T>` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ That's it! No macros or other setup needed!
     * Supports `push_back`, `pop_back`, `push_front`, `pop_front`, `emplace` and `erase` when appropriate.
 * `std::unique_ptr<T>`, `std::shared_ptr<T>`, `std::weak_ptr<T>`.
     * Acts the same as `T*`.
+* `std::indirect<T>`.
 * `std::function<Return()>`
     * Rendered as a button. Pressing the button calls the function.
     * The return value of type `Return` is discarded.

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -14,6 +14,7 @@
 #include <expected>
 #include <chrono>
 #include <inplace_vector>
+#include <memory>
 
 #include <imgui.h>
 #include <backends/imgui_impl_glfw.h>
@@ -44,7 +45,7 @@ enum colour
 
 struct player
 {
-    std::inplace_vector<int, 5> nums = {1, 2, 3, 4, 5};
+    std::indirect<int> x = std::indirect<int>{5};
 };
 
 int main()

--- a/imrefl.hpp
+++ b/imrefl.hpp
@@ -1196,6 +1196,20 @@ struct Renderer<config, std::unique_ptr<T, Deleter>>
     }
 };
 
+template <Config config, typename T, typename Allocator>
+struct Renderer<config, std::indirect<T, Allocator>>
+{
+    static bool Render(const char* name, std::indirect<T, Allocator>& value)
+    {
+        return Input<config>(name, *value);
+    }
+
+    static bool Render(const char* name, const std::indirect<T, Allocator>& value)
+    {
+        return Input<config>(name, *value);
+    }
+};
+
 template <Config config, typename T>
 struct Renderer<config, std::shared_ptr<T>>
 {


### PR DESCRIPTION
<img width="463" height="188" alt="image" src="https://github.com/user-attachments/assets/a8c61778-c238-40ac-941c-5ad88be9ec54" />

* Adds support for `std::indirect<T>`, which just delegates to the inner `T` renderer.
* Related is `std::polymorphic<T>` but I don't see how we can meaningfully do this since we don't know the actual held type.