### PR TITLE
Example overhaul

### DIFF
--- a/example/example.cpp
+++ b/example/example.cpp
@@ -49,6 +49,57 @@ struct player
     std::map<int, int> data;
 };
 
+struct example
+{
+    enum color
+    {
+        red,
+        orange,
+        yellow,
+        green,
+        blue,
+        violet
+    };
+
+    enum class shape
+    {
+        triangle,
+        square,
+        pentagon,
+        hexagon,
+        heptagon,
+        octagon
+    };
+
+    [[=ImRefl::begin_region("Enumeration types")]]
+    color enum_;
+    shape enum_class_;
+    [[=ImRefl::end_region()]]
+
+    [[=ImRefl::begin_region("Arithmetic types")]]
+    bool bool_;
+    char char_;
+
+    [[=ImRefl::begin_region("Signed integers")]]
+    short short_;
+    int int_;
+    long int l_int_;
+    long long int ll_int_;
+    [[=ImRefl::end_region()]]
+
+    [[=ImRefl::begin_region("Unsigned integers")]]
+    unsigned char u_char_;
+    unsigned short u_short_;
+    unsigned int u_int_;
+    unsigned long int u_l_int_;
+    unsigned long long int u_ll_int_;
+    [[=ImRefl::end_region()]]
+
+    [[=ImRefl::begin_region("Floating point")]]
+    float float_;
+    double double_;
+};
+
 int main()
 {
     glfwSetErrorCallback([](int err, const char* desc) {
@@ -79,7 +130,8 @@ int main()
     ImGui_ImplGlfw_InitForOpenGL(window, true);
     ImGui_ImplOpenGL3_Init("#version 330");
 
-    player p = {};
+    //player p = {};
+    example ex = {};
     while (!glfwWindowShouldClose(window)) {
         glfwPollEvents();
 
@@ -88,7 +140,7 @@ int main()
         ImGui::NewFrame();
 
         ImGui::Begin("Debug");
-        ImRefl::Input("Player", p);
+        ImRefl::Input("Example", ex);
         ImGui::End();
         ImGui::Render();
 

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -28,6 +28,8 @@ using namespace std::chrono;
 #include "imrefl.hpp"
 #include "imrefl_glm.hpp"
 
+int i = 49;
+
 struct example
 {
     enum color
@@ -52,87 +54,132 @@ struct example
 
     [[=ImRefl::begin_region("Enumeration types")]]
     color enum_;
+    const color const_enum_;
     shape enum_class_;
+    const shape const_enum_class_;
     [[=ImRefl::end_region()]]
 
     [[=ImRefl::begin_region("Arithmetic types")]]
     bool bool_;
+    const bool const_bool_ = true;
     char char_;
+    const char const_char_ = '!';
 
     [[=ImRefl::separator("Signed integers")]]
     short short_;
+    const short const_short_;
     int int_;
+    const int const_int_;
     long int l_int_;
+    const long int const_l_int_;
     long long int ll_int_;
+    const long long int const_ll_int_;
 
     [[=ImRefl::separator("Unsigned integers")]]
-    unsigned char u_char_;
-    unsigned short u_short_;
-    unsigned int u_int_;
-    unsigned long int u_l_int_;
-    unsigned long long int u_ll_int_;
+    unsigned char uchar_;
+    const unsigned char const_uchar_;
+    unsigned short ushort_;
+    const unsigned short const_ushort_;
+    unsigned int uint_;
+    const unsigned int const_uint_;
+    unsigned long int ul_int_;
+    const unsigned long int const_ul_int_;
+    unsigned long long int ull_int_;
+    const decltype(ull_int_) const_ull_int_;
 
     [[=ImRefl::separator("Floating point")]]
     float float_;
+    const float const_float_;
     double double_;
+    const double const_double_;
     [[=ImRefl::end_region()]]
 
     [[=ImRefl::begin_region("C types")]]
-    int* raw_ptr_;
+    int* raw_ptr_ = &i;
+    const int* const_raw_ptr_ = &i;
     int* null_raw_ptr_ = nullptr;
     float c_arr_[5];
+    const float const_c_arr_[5] = {0.f, 1.f, 2.f, 3.f, 4.f};
     [[=ImRefl::string]] char c_char_arr_[32];
     const char* c_str_ = "This is null terminated C string";
     [[=ImRefl::end_region()]]
 
     [[=ImRefl::begin_region("std:: types")]]
     std::string string_;
+    const std::string const_string_ = "This is a const-qualified string";
     std::string_view string_view_ = "This is a string_view";
     std::pair<int, float> pair_;
+    const decltype(pair_) const_pair_ = {3, 0.14f};
     std::tuple<int, float, bool> tuple_;
+    const decltype(tuple_) const_tuple_ = {4, 1.6f, true};
     std::optional<int> optional_ = 0;
+    const decltype(optional_) const_optional_ = 8;
     std::variant<int, float, bool> variant_;
+    const decltype(variant_) const_variant_ = false;
     std::expected<bool, int> expected_;
+    const decltype(expected_) const_expected_ = true;
     std::indirect<int> indirect_ = std::indirect<int>{};
+    const decltype(indirect_) const_indirect_ = std::indirect<int>{73};
 
     [[=ImRefl::separator("Pointer types")]]
-    std::unique_ptr<int> unique_ptr_;
-    std::shared_ptr<int> shared_ptr_;
-    std::weak_ptr<int> weak_ptr_;
+    std::unique_ptr<int> unique_ptr_ = std::make_unique<int>(i);
+    std::shared_ptr<int> shared_ptr_ = std::make_shared<int>(i);
+    std::weak_ptr<int> weak_ptr_ = shared_ptr_;
 
     [[=ImRefl::separator()]]
     std::function<void()> function_;
     std::source_location source_location_ = std::source_location::current();
     std::complex<float> complex_;
+    const decltype(complex_) const_complex_ = {2.45, 6.34};
     std::bitset<5> bitset_;
+    const decltype(bitset_) const_bitset_ = 0b10101;
 
     [[=ImRefl::begin_region("Container types")]]
     std::array<int, 5> array_;
+    const decltype(array_) const_array_ = {4, 3, 2, 1, 0};
     std::span<int, 5> span_ = array_;
+    std::span<const int, 5> const_span_ = const_array_;
     std::vector<int> vector_;
+    const decltype(vector_) const_vector_ = {3, 6, 2, 7};
     std::deque<int> deque_;
+    const decltype(deque_) const_deque_ = {7, 4, 9, 6};
     std::list<int> list_;
+    const decltype(list_) const_list_ = {67, 9, 47, 2};
     std::forward_list<int> forward_list_;
+    const decltype(forward_list_) const_forward_list_ = {76, 854, 234, 8};
 
     [[=ImRefl::separator("Set types")]]
     std::set<int> set_;
+    const decltype(set_) const_set_ = {63, 75, 2, 5};
     std::unordered_set<int> unordered_set_;
+    const decltype(unordered_set_) const_unordered_set_ = {34, 745, 9, 3};
     std::multiset<int> multiset_;
+    const decltype(multiset_) const_multiset_ = {45, 67, 45, 93};
     std::unordered_multiset<int> unordered_multiset_;
+    const decltype(unordered_multiset_) const_unordered_multiset_ = {75, 988, 988, 7};
 
     [[=ImRefl::separator("Map types")]]
     std::map<int, float> map_;
+    const decltype(map_) const_map_ = {{4, 5.7f}, {8, 11.4f}};
     std::unordered_map<int, float> unordered_map_;
+    const decltype(unordered_map_) const_unordered_map_ = {{{10, 34.7f}, {5, 17.35f}}};
     std::multimap<int, float> multimap_;
+    const decltype(multimap_) const_multimap_ = {{5, 64.4f}, {5, 28.2f}};
     std::unordered_multimap<int, float> unordered_multimap_;
+    const decltype(unordered_multimap_) const_unordered_multimap_ = {{19, 0.02f}, {19, 4.254f}};
     std::inplace_vector<int, 5> inplace_vector_;
+    const decltype(inplace_vector_) const_inplace_vector_ = {3, 7, 23, 9, 10};
     [[=ImRefl::end_region()]]
 
     [[=ImRefl::begin_region("chrono:: types")]]
     system_clock::time_point time_point_ = system_clock::now();
-    duration<double> duration_ = 500ms;
-    year_month_day year_month_day_ = 1984y / February / 17;
-    hh_mm_ss<decltype(duration_)> hh_mm_ss_{days(3) + hours(4) + minutes(17) + seconds(48)};
+    const decltype(time_point_) const_time_point_ = time_point_;
+    duration<double> duration_ = time_point_ - const_time_point_;
+    const decltype(duration_) const_duration_ = 18952ms;
+    year_month_day year_month_day_ = 1989y / November / 9;
+    const year_month_day const_year_month_day_ = 1815y / February / 17;
+    hh_mm_ss<decltype(duration_)> hh_mm_ss_{hours(4) + minutes(17) + seconds(48)};
+    const decltype(hh_mm_ss_) const_hh_mm_ss_{hours(7) + minutes(48) + seconds(19)};
 };
 
 int main()
@@ -166,12 +213,6 @@ int main()
     ImGui_ImplOpenGL3_Init("#version 330");
     
     example ex = {};
-    int i = 0;
-    ex.raw_ptr_ = &i;
-    ex.shared_ptr_ = std::make_shared<int>(i);
-    *ex.shared_ptr_ = i;
-    ex.weak_ptr_ = ex.shared_ptr_;
-    ex.unique_ptr_ = std::make_unique<int>(i);
 
     auto func = []() {
         static size_t n = 0;
@@ -184,6 +225,7 @@ int main()
         glfwPollEvents();
 
         ex.time_point_ = system_clock::now();
+        ex.duration_ = ex.time_point_ - ex.const_time_point_;
 
         ImGui_ImplOpenGL3_NewFrame();
         ImGui_ImplGlfw_NewFrame();

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -98,6 +98,14 @@ struct example
     [[=ImRefl::begin_region("Floating point")]]
     float float_;
     double double_;
+    [[=ImRefl::end_region(2)]]
+
+    [[=ImRefl::begin_region("C types")]]
+    int* raw_ptr_;
+    int* null_raw_ptr_ = nullptr;
+    float c_arr_[5];
+    [[=ImRefl::string]] char c_char_arr_[32];
+    const char* c_str_ = "This is null terminated C string";
 };
 
 int main()
@@ -132,6 +140,9 @@ int main()
 
     //player p = {};
     example ex = {};
+    int i = 714;
+    ex.raw_ptr_ = &i;
+
     while (!glfwWindowShouldClose(window)) {
         glfwPollEvents();
 

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -138,10 +138,10 @@ struct example
     std::unordered_set<int> unordered_set_;
     std::multiset<int> multiset_;
     std::unordered_multiset<int> unordered_multiset_;
-    // BROKEN! std::map<int, float> map_;
-    // BROKEN! std::unordered_map<int, float> unordered_map_;
-    // BROKEN! std::multimap<int, float> multimap_;
-    // BROKEN! std::unordered_multimap<int, float> unordered_multimap_;
+    std::map<int, float> map_;
+    std::unordered_map<int, float> unordered_map_;
+    std::multimap<int, float> multimap_;
+    std::unordered_multimap<int, float> unordered_multimap_;
     std::inplace_vector<int, 5> inplace_vector_;
     [[=ImRefl::end_region()]]
 

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -13,6 +13,8 @@
 #include <vector>
 #include <expected>
 #include <chrono>
+using namespace std::chrono_literals;
+using namespace std::chrono;
 #include <inplace_vector>
 #include <memory>
 
@@ -106,6 +108,48 @@ struct example
     float c_arr_[5];
     [[=ImRefl::string]] char c_char_arr_[32];
     const char* c_str_ = "This is null terminated C string";
+    [[=ImRefl::end_region()]]
+
+    [[=ImRefl::begin_region("std:: types")]]
+    std::string string_;
+    std::string_view string_view_ = "This is a string_view";
+    std::pair<int, float> pair_;
+    std::tuple<int, float, bool> tuple_;
+    std::optional<int> optional_ = 0;
+    std::variant<int, float, bool> variant_;
+    std::indirect<int> indirect_ = std::indirect<int>{};
+    std::bitset<5> bitset_;
+    std::unique_ptr<int> unique_ptr_;
+    std::shared_ptr<int> shared_ptr_;
+    std::weak_ptr<int> weak_ptr_;
+    std::function<void()> function_;
+    std::source_location source_location_ = std::source_location::current();
+    std::complex<float> complex_;
+    std::expected<bool, int> expected_;
+
+    [[=ImRefl::begin_region("Container types")]]
+    std::array<int, 5> array_;
+    std::span<int, 5> span_ = array_;
+    std::vector<int> vector_;
+    std::deque<int> deque_;
+    std::list<int> list_;
+    std::forward_list<int> forward_list_;
+    std::set<int> set_;
+    std::unordered_set<int> unordered_set_;
+    std::multiset<int> multiset_;
+    std::unordered_multiset<int> unordered_multiset_;
+    // BROKEN! std::map<int, float> map_;
+    // BROKEN! std::unordered_map<int, float> unordered_map_;
+    // BROKEN! std::multimap<int, float> multimap_;
+    // BROKEN! std::unordered_multimap<int, float> unordered_multimap_;
+    std::inplace_vector<int, 5> inplace_vector_;
+    [[=ImRefl::end_region()]]
+
+    [[=ImRefl::begin_region("chrono:: types")]]
+    system_clock::time_point time_point_ = std::chrono::system_clock::now();
+    duration<double> duration_ = 500ms;
+    year_month_day year_month_day_ = 1984y / February / 17;
+    hh_mm_ss<decltype(duration_)> hh_mm_ss_{days(3) + hours(4) + minutes(17) + seconds(48)};
 };
 
 int main()
@@ -140,8 +184,20 @@ int main()
 
     //player p = {};
     example ex = {};
-    int i = 714;
+
+    int i = 0;
     ex.raw_ptr_ = &i;
+    ex.shared_ptr_ = std::make_shared<int>(i);
+    *ex.shared_ptr_ = i;
+    ex.weak_ptr_ = ex.shared_ptr_;
+    ex.unique_ptr_ = std::make_unique<int>(i);
+
+    auto func = []() {
+        static size_t n = 0;
+        ++n;
+        std::println("Function called {} time{}", n, n == 1 ? "" : "s");
+    };
+    ex.function_ = func;
 
     while (!glfwWindowShouldClose(window)) {
         glfwPollEvents();

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -179,8 +179,14 @@ struct example
     year_month_day year_month_day_ = 1989y / November / 9;
     const year_month_day const_year_month_day_ = 1815y / February / 17;
     hh_mm_ss<decltype(duration_)> hh_mm_ss_{hours(4) + minutes(17) + seconds(48)};
-    const decltype(hh_mm_ss_) const_hh_mm_ss_{hours(7) + minutes(48) + seconds(19)};\
+    const decltype(hh_mm_ss_) const_hh_mm_ss_{hours(7) + minutes(48) + seconds(19)};
     [[=ImRefl::end_region(2)]]
+
+    [[=ImRefl::begin_region("GLM types")]]
+    [[=ImRefl::in_line]] glm::vec4 glm_vec_;
+    [[=ImRefl::in_line]] glm::ivec4 glm_ivec_;
+    [[=ImRefl::in_line]] glm::dvec4 glm_dvec_;
+    [[=ImRefl::end_region()]]
 
     [[=ImRefl::begin_region("Style annotations")]]
     [[=ImRefl::ignore]] int ignore_attn_;

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -28,29 +28,6 @@ using namespace std::chrono;
 #include "imrefl.hpp"
 #include "imrefl_glm.hpp"
 
-enum class weapon
-{
-    none,
-    sword,
-    bow,
-    staff,
-    wand,
-    axe
-};
-
-enum colour
-{
-    green,
-    blue,
-    red
-};
-
-struct player
-{
-    std::indirect<int> x = std::indirect<int>{5};
-    std::map<int, int> data;
-};
-
 struct example
 {
     enum color
@@ -82,25 +59,23 @@ struct example
     bool bool_;
     char char_;
 
-    [[=ImRefl::begin_region("Signed integers")]]
+    [[=ImRefl::separator("Signed integers")]]
     short short_;
     int int_;
     long int l_int_;
     long long int ll_int_;
-    [[=ImRefl::end_region()]]
 
-    [[=ImRefl::begin_region("Unsigned integers")]]
+    [[=ImRefl::separator("Unsigned integers")]]
     unsigned char u_char_;
     unsigned short u_short_;
     unsigned int u_int_;
     unsigned long int u_l_int_;
     unsigned long long int u_ll_int_;
-    [[=ImRefl::end_region()]]
 
-    [[=ImRefl::begin_region("Floating point")]]
+    [[=ImRefl::separator("Floating point")]]
     float float_;
     double double_;
-    [[=ImRefl::end_region(2)]]
+    [[=ImRefl::end_region()]]
 
     [[=ImRefl::begin_region("C types")]]
     int* raw_ptr_;
@@ -117,15 +92,19 @@ struct example
     std::tuple<int, float, bool> tuple_;
     std::optional<int> optional_ = 0;
     std::variant<int, float, bool> variant_;
+    std::expected<bool, int> expected_;
     std::indirect<int> indirect_ = std::indirect<int>{};
-    std::bitset<5> bitset_;
+
+    [[=ImRefl::separator("Pointer types")]]
     std::unique_ptr<int> unique_ptr_;
     std::shared_ptr<int> shared_ptr_;
     std::weak_ptr<int> weak_ptr_;
+
+    [[=ImRefl::separator()]]
     std::function<void()> function_;
     std::source_location source_location_ = std::source_location::current();
     std::complex<float> complex_;
-    std::expected<bool, int> expected_;
+    std::bitset<5> bitset_;
 
     [[=ImRefl::begin_region("Container types")]]
     std::array<int, 5> array_;
@@ -134,10 +113,14 @@ struct example
     std::deque<int> deque_;
     std::list<int> list_;
     std::forward_list<int> forward_list_;
+
+    [[=ImRefl::separator("Set types")]]
     std::set<int> set_;
     std::unordered_set<int> unordered_set_;
     std::multiset<int> multiset_;
     std::unordered_multiset<int> unordered_multiset_;
+
+    [[=ImRefl::separator("Map types")]]
     std::map<int, float> map_;
     std::unordered_map<int, float> unordered_map_;
     std::multimap<int, float> multimap_;
@@ -146,7 +129,7 @@ struct example
     [[=ImRefl::end_region()]]
 
     [[=ImRefl::begin_region("chrono:: types")]]
-    system_clock::time_point time_point_ = std::chrono::system_clock::now();
+    system_clock::time_point time_point_ = system_clock::now();
     duration<double> duration_ = 500ms;
     year_month_day year_month_day_ = 1984y / February / 17;
     hh_mm_ss<decltype(duration_)> hh_mm_ss_{days(3) + hours(4) + minutes(17) + seconds(48)};
@@ -181,10 +164,8 @@ int main()
 
     ImGui_ImplGlfw_InitForOpenGL(window, true);
     ImGui_ImplOpenGL3_Init("#version 330");
-
-    //player p = {};
+    
     example ex = {};
-
     int i = 0;
     ex.raw_ptr_ = &i;
     ex.shared_ptr_ = std::make_shared<int>(i);
@@ -201,6 +182,8 @@ int main()
 
     while (!glfwWindowShouldClose(window)) {
         glfwPollEvents();
+
+        ex.time_point_ = system_clock::now();
 
         ImGui_ImplOpenGL3_NewFrame();
         ImGui_ImplGlfw_NewFrame();

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -179,7 +179,20 @@ struct example
     year_month_day year_month_day_ = 1989y / November / 9;
     const year_month_day const_year_month_day_ = 1815y / February / 17;
     hh_mm_ss<decltype(duration_)> hh_mm_ss_{hours(4) + minutes(17) + seconds(48)};
-    const decltype(hh_mm_ss_) const_hh_mm_ss_{hours(7) + minutes(48) + seconds(19)};
+    const decltype(hh_mm_ss_) const_hh_mm_ss_{hours(7) + minutes(48) + seconds(19)};\
+    [[=ImRefl::end_region(2)]]
+
+    [[=ImRefl::begin_region("Style annotations")]]
+    [[=ImRefl::ignore]] int ignore_attn_;
+    [[=ImRefl::readonly]] int readonly_attn_;
+    [[=ImRefl::slider(-100, 100)]] int slider_attn_;
+    [[=ImRefl::drag(0, 100, 0.01f)]] float drag_attn_;
+    [[=ImRefl::color]] float color_attn_[3];
+    [[=ImRefl::color_wheel]] float color_wheel_attn_[4];
+    [[=ImRefl::string]] char string_attn_[32];
+    [[=ImRefl::radio]] shape radio_attn_;
+    [[=ImRefl::in_line]] float in_line_attn_[3];
+    [[=ImRefl::non_resizable]] std::vector<int> non_resizable_attn_ = {0, 0, 0, 0};
 };
 
 int main()

--- a/imrefl.hpp
+++ b/imrefl.hpp
@@ -494,7 +494,7 @@ bool render_forward_range(const char* name, R& range)
     }
 
     std::size_t i = 0;
-    for (auto it = range.begin(); it != range.end();) {
+    for (auto it = range.begin(); it != range.end(); ++it) {
         changed |= render_range_element<config>(name, i, range, it);
         ++i;
     }

--- a/imrefl.hpp
+++ b/imrefl.hpp
@@ -494,7 +494,7 @@ bool render_forward_range(const char* name, R& range)
     }
 
     std::size_t i = 0;
-    for (auto it = range.begin(); it != range.end(); ++it) {
+    for (auto it = range.begin(); it != range.end();) {
         changed |= render_range_element<config>(name, i, range, it);
         ++i;
     }

--- a/imrefl.hpp
+++ b/imrefl.hpp
@@ -955,6 +955,16 @@ struct Renderer<config, std::span<const T>>
 };
 
 template <Config config>
+struct Renderer<config, const char*>
+{
+    static bool Render(const char* name, const char* value)
+    {
+        ImGui::Text("%s: %s", name, value);
+        return false;
+    }
+};
+
+template <Config config>
 struct Renderer<config, std::string>
 {
     static bool Render(const char* name, std::string& value)
@@ -979,8 +989,7 @@ struct Renderer<config, std::string>
 
     static bool Render(const char* name, const std::string& value)
     {
-        ImGui::Text("%s: %s", name, value.c_str());
-        return false;
+        return Renderer<config, const char*>::Render(name, value.c_str());
     }
 };
 

--- a/imrefl.hpp
+++ b/imrefl.hpp
@@ -1071,7 +1071,6 @@ struct Renderer<config, std::optional<T>>
     {
         const ImGuiStyle& style = ImGui::GetStyle();
         if (value.has_value()) {
-            ImGui::SetNextItemWidth(ImGui::CalcItemWidth() - (ImGui::GetItemRectSize().x + style.ItemInnerSpacing.x));
             Input<config>(name, *value);
         } else {
             ImGui::Text("%s: <empty>", name);


### PR DESCRIPTION
This PR aims to introduce a complete example that uses all types said to be supported in the README. The goal is to provide users with a reference to how types are rendered and how to use annotations, as well as making regressions readily apparent.

As of now, all types listed in the README (apart from `map` types) of the mutable variation are included in the example. 

## TODO
- ~~Organize types using `region` and `separator` annotations~~
- ~~Write examples for all style annotations~~
- ~~Fix `map` types~~
- ~~`const` types~~