### PR TITLE
Fix typo in `is_map_type` concept

### DIFF
--- a/example/example.cpp
+++ b/example/example.cpp
@@ -46,6 +46,7 @@ enum colour
 struct player
 {
     std::indirect<int> x = std::indirect<int>{5};
+    std::map<int, int> data;
 };
 
 int main()

--- a/imrefl.hpp
+++ b/imrefl.hpp
@@ -224,6 +224,11 @@ concept is_map_type =
         { t.emplace(key, value) };
     };
 
+static_assert(is_map_type<std::map<int, int>>);
+static_assert(is_map_type<std::unordered_map<int, float>>);
+static_assert(!is_map_type<std::set<int>>);
+static_assert(!is_map_type<int>);
+
 template <typename T>
 concept is_set_type =
     !is_map_type<T> &&
@@ -235,6 +240,11 @@ concept is_set_type =
     requires(T t, typename T::key_type key) {
         { t.emplace(key) };
     };
+
+static_assert(is_set_type<std::set<int>>);
+static_assert(is_set_type<std::unordered_set<int>>);
+static_assert(!is_set_type<std::map<int, int>>);
+static_assert(!is_set_type<int>);
 
 // INTERNAL HELPERS
 

--- a/imrefl.hpp
+++ b/imrefl.hpp
@@ -220,7 +220,7 @@ concept is_map_type =
     } &&
     std::default_initializable<typename T::key_type> &&
     std::default_initializable<typename T::mapped_type> &&
-    requires(T t, typename T::key_type key, typename T::mapping_type value) {
+    requires(T t, typename T::key_type key, typename T::mapped_type value) {
         { t.emplace(key, value) };
     };
 


### PR DESCRIPTION
* I had a typo in the `is_map_type` concept, resulting in the map branch not being taken for map types, meaning they would fall into the set branch, at which the `emplace` would fail. Annoyingly I spelt it correctly further up in the concept and didn't notice.
* Because of SFINAE, this wasn't a compiler error; a good lesson in always being careful with your concepts! To avoid this, I've added some `static_assert`s for the map and set concepts to ensure this doesn't happen again.