### PR TITLE
CMake: MinGW improvements

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -50,12 +50,11 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
 endif()
 
 if (MINGW AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  target_link_libraries(imrefl-example PRIVATE stdc++exp)
+  target_link_libraries(imrefl-example PRIVATE stdc++exp -static)
 endif()
 
 target_link_libraries(imrefl-example PRIVATE
   ${OPENGL_LIBRARIES}
   glfw
   ImRefl
-  -static
 )

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,7 +1,14 @@
-find_package(glfw3 REQUIRED)
 find_package(OpenGL REQUIRED)
 
 include(FetchContent)
+
+FetchContent_Declare(
+  glfw
+  GIT_REPOSITORY https://github.com/glfw/glfw.git
+)
+message("Fetching glfw...")
+FetchContent_MakeAvailable(glfw)
+
 FetchContent_Declare(
   imgui
   GIT_REPOSITORY https://github.com/ocornut/imgui.git
@@ -42,8 +49,13 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   )
 endif()
 
+if (MINGW AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  target_link_libraries(imrefl-example PRIVATE stdc++exp)
+endif()
+
 target_link_libraries(imrefl-example PRIVATE
   ${OPENGL_LIBRARIES}
   glfw
   ImRefl
+  -static
 )


### PR DESCRIPTION
The most notable change this PR makes is moving away from `find_package` for glfw; it works fine on Linux, but on Windows a full MinGW environment is necessary and glfw installed with pacman for this to work. Even then, the glfw package only ships with a shared library and it's a pain to run the example outside of this environment. Switching to `FetchContent` and building glfw from source allows a fully standalone binary on Windows.