### PR TITLE
Flat container support

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ That's it! No macros or other setup needed!
     * `std::multimap<K, V>`.
     * `std::unordered_multimap<K, V>`.
     * `std::inplace_vector<T, N>`.
+    * `std::flat_map<K, V>`.
+    * `std::flat_set<T>`.
+    * `std::flat_multimap<K, V>`.
+    * `std::flat_multiset<T>`.
     * Supports `push_back`, `pop_back`, `push_front`, `pop_front`, `emplace` and `erase` when appropriate.
 * `std::unique_ptr<T>`, `std::shared_ptr<T>`, `std::weak_ptr<T>`.
     * Acts the same as `T*`.

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -1,22 +1,24 @@
 #include <array>
+#include <chrono>
+#include <chrono>
 #include <climits>
 #include <deque>
+#include <expected>
+#include <flat_map>
+#include <flat_set>
 #include <forward_list>
+#include <functional>
+#include <inplace_vector>
 #include <list>
+#include <map>
+#include <set>
+#include <unordered_map>
+#include <memory>
 #include <print>
 #include <set>
 #include <string>
-#include <chrono>
-#include <functional>
 #include <unordered_set>
-#include <map>
 #include <vector>
-#include <expected>
-#include <chrono>
-using namespace std::chrono_literals;
-using namespace std::chrono;
-#include <inplace_vector>
-#include <memory>
 
 #include <imgui.h>
 #include <backends/imgui_impl_glfw.h>
@@ -27,6 +29,9 @@ using namespace std::chrono;
 
 #include "imrefl.hpp"
 #include "imrefl_glm.hpp"
+
+using namespace std::chrono_literals;
+using namespace std::chrono;
 
 int i = 49;
 
@@ -169,6 +174,9 @@ struct example
     const decltype(unordered_multimap_) const_unordered_multimap_ = {{19, 0.02f}, {19, 4.254f}};
     std::inplace_vector<int, 5> inplace_vector_;
     const decltype(inplace_vector_) const_inplace_vector_ = {3, 7, 23, 9, 10};
+
+    std::flat_map<int, float> flat_map_;
+    const decltype(map_) const_flat_map_ = {{8, 4.3f}, {9, 12.5f}};
     [[=ImRefl::end_region()]]
 
     [[=ImRefl::begin_region("chrono:: types")]]

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -287,4 +287,3 @@ int main()
     glfwTerminate();
     return 0;
 }
-

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -152,6 +152,8 @@ struct example
     const decltype(list_) const_list_ = {67, 9, 47, 2};
     std::forward_list<int> forward_list_;
     const decltype(forward_list_) const_forward_list_ = {76, 854, 234, 8};
+    std::inplace_vector<int, 5> inplace_vector_;
+    const decltype(inplace_vector_) const_inplace_vector_ = {3, 7, 23, 9, 10};
 
     [[=ImRefl::separator("Set types")]]
     std::set<int> set_;
@@ -168,15 +170,20 @@ struct example
     const decltype(map_) const_map_ = {{4, 5.7f}, {8, 11.4f}};
     std::unordered_map<int, float> unordered_map_;
     const decltype(unordered_map_) const_unordered_map_ = {{{10, 34.7f}, {5, 17.35f}}};
+
     std::multimap<int, float> multimap_;
     const decltype(multimap_) const_multimap_ = {{5, 64.4f}, {5, 28.2f}};
     std::unordered_multimap<int, float> unordered_multimap_;
     const decltype(unordered_multimap_) const_unordered_multimap_ = {{19, 0.02f}, {19, 4.254f}};
-    std::inplace_vector<int, 5> inplace_vector_;
-    const decltype(inplace_vector_) const_inplace_vector_ = {3, 7, 23, 9, 10};
 
     std::flat_map<int, float> flat_map_;
-    const decltype(map_) const_flat_map_ = {{8, 4.3f}, {9, 12.5f}};
+    const decltype(flat_map_) const_flat_map_ = {{8, 4.3f}, {9, 12.5f}};
+    std::flat_set<int> flat_set_;
+    const decltype(flat_set_) const_flat_set_ = {8, 9};
+    std::flat_multimap<int, float> flat_multimap_;
+    const decltype(flat_multimap_) const_flat_multimap_ = {{8, 4.3f}, {8, 12.5f}};
+    std::flat_multiset<int> flat_multiset_;
+    const decltype(flat_multiset_) const_flat_multiset_ = {8, 8};
     [[=ImRefl::end_region()]]
 
     [[=ImRefl::begin_region("chrono:: types")]]

--- a/imrefl.hpp
+++ b/imrefl.hpp
@@ -11,18 +11,23 @@
 #include <expected>
 #include <format>
 #include <functional>
+#include <map>
 #include <memory>
 #include <meta>
 #include <numeric>
 #include <optional>
 #include <ranges>
+#include <set>
 #include <source_location>
-#include <string>
 #include <stack>
+#include <string>
 #include <string_view>
 #include <type_traits>
+#include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <variant>
+#include <vector>
 
 namespace ImRefl {
 
@@ -246,6 +251,16 @@ static_assert(is_set_type<std::unordered_set<int>>);
 static_assert(!is_set_type<std::map<int, int>>);
 static_assert(!is_set_type<int>);
 
+template <typename R>
+concept is_swappable =
+    std::ranges::random_access_range<R> &&
+    requires(std::ranges::range_reference_t<R> a, std::ranges::range_reference_t<R> b) {
+        std::swap(a, b);
+    };
+
+static_assert(is_swappable<std::vector<int>>);
+static_assert(!is_swappable<std::unordered_map<int, int>>);
+
 // INTERNAL HELPERS
 
 consteval auto nsdm_of(std::meta::info type)
@@ -391,13 +406,11 @@ bool render_pointer_as_value(const char* name, T* value)
 template <Config config, std::ranges::forward_range R>
 bool render_range_element(const char* name, std::size_t i, R& range, std::ranges::iterator_t<R>& it)
 {
-    constexpr auto is_const_range = is_const_type(remove_reference(^^std::ranges::range_reference_t<R>));
-
     const auto index_name = fmt("[{}]", i);
-    auto& element = *it;
+    auto&& element = *it;
 
     bool changed = false;
-    if constexpr (!is_const_range && std::ranges::random_access_range<R>) {
+    if constexpr (detail::is_swappable<R>) {
         changed = Input<config>(fmt("##{}", i), element);
 
         ImGui::SameLine();

--- a/imrefl.hpp
+++ b/imrefl.hpp
@@ -544,7 +544,7 @@ bool render_forward_range(const char* name, const R& range)
 {
     if (TreeNodeExNoDisable(name)) {
         std::size_t i = 0;
-        for (auto& element : range) {
+        for (auto&& element : range) {
             Input<config>(fmt("[{}]", i), element); 
             ++i;
         }

--- a/imrefl.hpp
+++ b/imrefl.hpp
@@ -259,6 +259,7 @@ concept is_swappable =
     };
 
 static_assert(is_swappable<std::vector<int>>);
+static_assert(!is_swappable<const std::vector<int>>);
 static_assert(!is_swappable<std::unordered_map<int, int>>);
 
 // INTERNAL HELPERS


### PR DESCRIPTION
Resolves https://github.com/fullptr/imrefl/issues/110.

* Adds support for `std::flat_map`, `std::flat_set`, `std::flat_multimap` and `std::flat_multiset`.
* This was achieved by making `render_forward_range` more robust:
    * To implement swapping, we were checking that the given range was non-const and random-access, however, `std::flat_map` is a random access container (unlike the other map types), but not swappable, since `std::flat_map<K, V>::reference` isn't actually a reference, but a pair of references. Now we have a concept that just checks if `std::swap` is possible.
    * A couple of places where we had `auto&` are now the more correct `auto&&` which can handle the places where the `::reference` isn't actually a reference.