### PR TITLE
Help tooltips

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ That's it! No macros or other setup needed!
 | `ImRefl::separator(title)` | Adds an ImGui separator line with optional title above the annotated field. |
 | `ImRefl::begin_region(title)` | Adds a collapsible region within an aggregate. |
 | `ImRefl::end_region(levels)` | Closes a collapsible region; defaults to 1 level, 0 is used to close all nested regions in the stack. | 
+| `ImRefl::help(text)` | Adds a "(?)" marker after the field that shows `text` in a tooltip when hovered. |
 
 ### Third-party types
 It is possible to implement the rendering logic for custom types by providing an implementation of `ImRefl::Renderer` for your type. For example:

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ That's it! No macros or other setup needed!
 | `ImRefl::separator(title)` | Adds an ImGui separator line with optional title above the annotated field. |
 | `ImRefl::begin_region(title)` | Adds a collapsible region within an aggregate. |
 | `ImRefl::end_region(levels)` | Closes a collapsible region; defaults to 1 level, 0 is used to close all nested regions in the stack. | 
-| `ImRefl::help(text)` | Adds a "(?)" marker after the field that shows `text` in a tooltip when hovered. |
+| `ImRefl::help(text, label="(?)")` | Adds a marker (`label`, defaulting to `"(?)"`) after the field that shows `text` in a tooltip when hovered. |
 
 ### Third-party types
 It is possible to implement the rendering logic for custom types by providing an implementation of `ImRefl::Renderer` for your type. For example:

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -214,6 +214,7 @@ struct example
     [[=ImRefl::radio]] shape radio_attn_;
     [[=ImRefl::in_line]] float in_line_attn_[3];
     [[=ImRefl::non_resizable]] std::vector<int> non_resizable_attn_ = {0, 0, 0, 0};
+    [[=ImRefl::help("This field has a tooltip explaining what it does.")]] int help_attn_;
 };
 
 int main()

--- a/imrefl.hpp
+++ b/imrefl.hpp
@@ -368,7 +368,7 @@ bool square_button(const char* name)
 inline void render_help_marker(const char* text, const char* label)
 {
     ImGui::SameLine();
-    ImGui::TextDisabled(label);
+    ImGui::TextDisabled("%s", label);
     if (ImGui::BeginItemTooltip()) {
         ImGui::TextUnformatted(text);
         ImGui::EndTooltip();

--- a/imrefl.hpp
+++ b/imrefl.hpp
@@ -137,6 +137,9 @@ inline static constexpr String string {};
 struct Radio {};
 inline static constexpr Radio radio {};
 
+struct Help { const char* text; };
+consteval Help help(std::string_view text) { return {std::define_static_string(text)}; }
+
 // ============================================================================
 // LIBRARY UTILITY 
 // ============================================================================
@@ -348,6 +351,18 @@ bool square_button(const char* name)
 {
     const float button_size = ImGui::GetFrameHeight();
     return ImGui::Button(name, {button_size, button_size});
+}
+
+// Renders a "(?)" marker after the current item, showing the given text
+// in a tooltip when hovered.
+inline void render_help_marker(const char* text)
+{
+    ImGui::SameLine();
+    ImGui::TextDisabled("(?)");
+    if (ImGui::BeginItemTooltip()) {
+        ImGui::TextUnformatted(text);
+        ImGui::EndTooltip();
+    }
 }
 
 // Stores an object of type T in static storage and implements a popup
@@ -698,6 +713,10 @@ struct Renderer<config, T>
                         } else {
                             changed = Input<new_config>(identifier_of(member).data(), x.[:member:]) || changed;
                         }
+
+                        if constexpr (constexpr auto help = new_config.FetchAttn<Help>()) {
+                            detail::render_help_marker(help->text);
+                        }
                     }
                 }
             }
@@ -752,6 +771,10 @@ struct Renderer<config, T>
                         }
     
                         Input<new_config>(identifier_of(member).data(), x.[:member:]);
+
+                        if constexpr (constexpr auto help = new_config.FetchAttn<Help>()) {
+                            detail::render_help_marker(help->text);
+                        }
                     }
                 }
             }

--- a/imrefl.hpp
+++ b/imrefl.hpp
@@ -137,8 +137,18 @@ inline static constexpr String string {};
 struct Radio {};
 inline static constexpr Radio radio {};
 
-struct Help { const char* text; };
-consteval Help help(std::string_view text) { return {std::define_static_string(text)}; }
+struct Help
+{
+    const char* text;
+    const char* label;
+};
+consteval Help help(std::string_view text, std::string_view label = "(?)")
+{
+    return {
+        std::define_static_string(text),
+        std::define_static_string(label)
+    };
+}
 
 // ============================================================================
 // LIBRARY UTILITY 
@@ -353,12 +363,12 @@ bool square_button(const char* name)
     return ImGui::Button(name, {button_size, button_size});
 }
 
-// Renders a "(?)" marker after the current item, showing the given text
-// in a tooltip when hovered.
-inline void render_help_marker(const char* text)
+// Renders the given label after the current item,
+// showing the given text in a tooltip when hovered.
+inline void render_help_marker(const char* text, const char* label)
 {
     ImGui::SameLine();
-    ImGui::TextDisabled("(?)");
+    ImGui::TextDisabled(label);
     if (ImGui::BeginItemTooltip()) {
         ImGui::TextUnformatted(text);
         ImGui::EndTooltip();
@@ -715,7 +725,7 @@ struct Renderer<config, T>
                         }
 
                         if constexpr (constexpr auto help = new_config.FetchAttn<Help>()) {
-                            detail::render_help_marker(help->text);
+                            detail::render_help_marker(help->text, help->label);
                         }
                     }
                 }
@@ -773,7 +783,7 @@ struct Renderer<config, T>
                         Input<new_config>(identifier_of(member).data(), x.[:member:]);
 
                         if constexpr (constexpr auto help = new_config.FetchAttn<Help>()) {
-                            detail::render_help_marker(help->text);
+                            detail::render_help_marker(help->text, help->label);
                         }
                     }
                 }


### PR DESCRIPTION
<img width="894" height="84" alt="image" src="https://github.com/user-attachments/assets/f0970326-921f-461d-bf22-9a2c5a9ba4c7" />

* Annotation to render a help tooltip.
* Originally I was going to make it show the tooltip when hovering any part of the widget, but that doesn't work too well with nested structs, so instead I opted to have an extra piece of text that the tooltip is applied to.
* It's possible to change the displayed text, by default it uses "(?)".